### PR TITLE
Fix the conversion error

### DIFF
--- a/mcts/mcts_main.cc
+++ b/mcts/mcts_main.cc
@@ -266,7 +266,7 @@ void GTPServing(std::istream &in, std::ostream &out)
         google::FlushLogFiles(google::INFO);
 
         std::istringstream ss(cmd);
-        if ((has_id = (ss >> id))) {
+        if ((has_id = (bool)(ss >> id))) {
             std::getline(ss, cmd);
         }
 


### PR DESCRIPTION
As of C++11, iostream classes are no longer implicitly convertible to void* so it is no longer valid to do something like:
```
bool valid(std::ostream& os) { return os; }
```
Such code must be changed to convert the iostream object to bool explicitly, e.g. `return (bool)os;` or `return static_cast<bool>(os);`