### PR TITLE
Fix error downloading boost dependency

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,11 +29,10 @@ http_archive(
 load('@org_tensorflow//tensorflow:workspace.bzl', 'tf_workspace')
 tf_workspace(path_prefix = "", tf_repo_name = "org_tensorflow")
 
-http_archive(
+git_repository(
     name = "com_github_nelhage_rules_boost",
-    urls = ["https://github.com/nelhage/rules_boost/archive/769c22fa72177314cd6fae505bd36116d6ed1f6b.tar.gz"],
-    sha256 = "b2fccaabeb6ee243c7632dd2a4d0419c78e43e1f063cb4b6a117630d060b440e",
-    strip_prefix = "rules_boost-769c22fa72177314cd6fae505bd36116d6ed1f6b",
+    commit = "c1975a9a45c97823ae9e68fbccb821418099168f",
+    remote = "https://github.com/nelhage/rules_boost",
 )
 
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -29,10 +29,11 @@ http_archive(
 load('@org_tensorflow//tensorflow:workspace.bzl', 'tf_workspace')
 tf_workspace(path_prefix = "", tf_repo_name = "org_tensorflow")
 
-git_repository(
+http_archive(
     name = "com_github_nelhage_rules_boost",
-    commit = "c1975a9a45c97823ae9e68fbccb821418099168f",
-    remote = "https://github.com/nelhage/rules_boost",
+    urls = ["https://github.com/nelhage/rules_boost/archive/c1975a9a45c97823ae9e68fbccb821418099168f.tar.gz"],
+    sha256 = "ab8403986bea12da70c1ed86ef688e72c3062dd6b6a9a84035c4f13145defb93",
+    strip_prefix = "rules_boost-c1975a9a45c97823ae9e68fbccb821418099168f",
 )
 
 load("@com_github_nelhage_rules_boost//:boost/boost.bzl", "boost_deps")


### PR DESCRIPTION
Caused by the changed configuration of the boost download server
Ref: https://github.com/nelhage/rules_boost/issues/79, the boost dependency has been changed.