### PR TITLE
Faqv3 bazel master : move GorReviewPartner to .md doc, add all-in-one command in FAQ + word wrap in all docs and README + minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,21 +26,32 @@ If you use PhoenixGo in your research, please consider citing the library as fol
 #### Requirements
 
 * GCC with C++11 support
-* [Bazel](https://docs.bazel.build/versions/master/install.html) (**0.11.1 is known-good**)
+* Bazel (**0.11.1 is known-good**)
 * (Optional) CUDA and cuDNN for GPU support 
 * (Optional) TensorRT (for accelerating computation on GPU, 3.0.4 is known-good)
 
-The following environments have also been tested by independent contributors : [here](/docs/tested-versions.md). 
-Other versions may work, but they have not been tested (especially for bazel).
+The following environments have also been tested by independent contributors : 
+[here](/docs/tested-versions.md). Other versions may work, but they have not been 
+tested (especially for bazel).
 
-Recommendation : the bazel building uses a lot of RAM, if your building environment is lack of RAM, you may need to
-restart your computer and exit other running programs to free as much RAM as possible.
+#### Download and Install Bazel 
 
-Before starting : in the steps below, if you have issues on how to install or start bazel, 
-you may want to try this all-in-one command line for easier building instead, see
+Before starting, you need to download and install bazel.
+
+You can download and install bazel for linux systems
+[here](https://docs.bazel.build/versions/master/install.html)
+
+There are different methods to download and install bazel depending 
+on your linux system and settings (apt-get, install .sh, etc..)
+
+For PhoenixGo, bazel (**0.11.1 is known-good**), read 
+[Requirements](#requirements) for details
+
+If you have issues on how to install or start bazel, you may want 
+to try this all-in-one command line for easier building instead, see
 [FAQ question](/docs/FAQ.md#b0-it-is-too-hard-to-install-bazel-or-run-the-bazel-commands)
 
-#### Building
+#### Building PhoenixGo with Bazel
 
 Clone the repository and configure the building:
 
@@ -50,7 +61,8 @@ $ cd PhoenixGo
 $ ./configure
 ```
 
-`./configure` will ask where CUDA and TensorRT have been installed, specify them if need.
+`./configure` will start the bazel configure : ask where CUDA 
+and TensorRT have been installed, specify them if need.
 
 Then build with bazel:
 

--- a/README.md
+++ b/README.md
@@ -240,12 +240,14 @@ A copy of the `--help` is provided for your convenience [here](/docs/mcts-main-h
 
 It is possible to analyse .sgf files using analysis tools such as :
 - [GoReviewPartner](https://github.com/pnprog/goreviewpartner) : 
-an automated tool to analyse and/or review one or many .sgf files (saved as .rsgf file). 
-It supports PhoenixGo and other bots. See [FAQ question](/docs/FAQ.md/#a25-how-to-analyzereview-one-or-many-sgf-files-with-goreviewpartner) 
+an automated tool to analyse and/or review one or many .sgf files 
+(saved as .rsgf file). It supports PhoenixGo and other bots. See 
+[FAQ question](/docs/FAQ.md/#a25-how-to-analyzereview-one-or-many-sgf-files-with-goreviewpartner) 
 for details
 
-For analysis purpose, an easy way to display the PV (variations for main move path) is `--logtostderr --v=1` 
-which will display the main move path winrate and continuation of moves analyzed, see 
+For analysis purpose, an easy way to display the PV (variations for 
+main move path) is `--logtostderr --v=1` which will display the main 
+move path winrate and continuation of moves analyzed, see 
 [FAQ question](/docs/FAQ.md/#a2-where-is-the-pv-analysis-) for details
 
 ## FAQ

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Other versions may work, but they have not been tested (especially for bazel).
 Recommendation : the bazel building uses a lot of RAM, if your building environment is lack of RAM, you may need to
 restart your computer and exit other running programs to free as much RAM as possible.
 
+Before starting : in the steps below, if you have issues on how to install or start bazel, 
+you may want to try this all-in-one command line for easier building instead, see
+[FAQ question](/docs/FAQ.md#b0-it-is-too-hard-to-install-bazel-or-run-the-bazel-commands)
+
 #### Building
 
 Clone the repository and configure the building:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 **PhoenixGo** is a Go AI program which implements the AlphaGo Zero paper
 "[Mastering the game of Go without human knowledge](https://deepmind.com/documents/119/agz_unformatted_nature.pdf)".
-It is also known as "BensonDarr" and "金毛测试" in [FoxGo](http://weiqi.qq.com/), "cronus" in [CGOS](http://www.yss-aya.com/cgos/),
-and the champion of [World AI Go Tournament 2018](http://weiqi.qq.com/special/109) held in Fuzhou China.
+It is also known as "BensonDarr" and "金毛测试" in [FoxGo](http://weiqi.qq.com/), 
+"cronus" in [CGOS](http://www.yss-aya.com/cgos/), and the champion of 
+[World AI Go Tournament 2018](http://weiqi.qq.com/special/109) held in Fuzhou China.
 
 If you use PhoenixGo in your project, please consider mentioning in your README.
 
@@ -70,21 +71,32 @@ Then build with bazel:
 $ bazel build //mcts:mcts_main
 ```
 
-Dependices such as Tensorflow will be downloaded automatically. The building prosess may take a long time.
+Dependices such as Tensorflow will be downloaded automatically. 
+The building process may take a long time.
 
-#### Running
+Recommendation : the bazel building uses a lot of RAM, 
+if your building environment is lack of RAM, you may need to restart 
+your computer and exit other running programs to free as much RAM 
+as possible.
+
+#### Running PhoenixGo
 
 Download and extract the trained network:
+
 ```
 $ wget https://github.com/Tencent/PhoenixGo/releases/download/trained-network-20b-v1/trained-network-20b-v1.tar.gz
 $ tar xvzf trained-network-20b-v1.tar.gz
 ```
 
-The PhoenixGo engine supports GTP [(Go Text Protocol)](https://senseis.xmp.net/?GoTextProtocol),
-which means it can be used with a GUI with GTP capability, such as [Sabaki](http://sabaki.yichuanshen.de).
-It can also run on command-line GTP server tools like [gtp2ogs](https://github.com/online-go/gtp2ogs).
+The PhoenixGo engine supports GTP 
+[(Go Text Protocol)](https://senseis.xmp.net/?GoTextProtocol),
+which means it can be used with a GUI with GTP capability, such as 
+[Sabaki](http://sabaki.yichuanshen.de).
+It can also run on command-line GTP server tools like 
+[gtp2ogs](https://github.com/online-go/gtp2ogs).
 
-But PhoenixGo does not support all GTP commands, see [FAQ question](/docs/FAQ.md/#a11-gtp-command-error--invalid-command).
+But PhoenixGo does not support all GTP commands, see 
+[FAQ question](/docs/FAQ.md/#a11-gtp-command-error--invalid-command).
 
 There are 2 ways to run PhoenixGo engine
 
@@ -92,34 +104,42 @@ There are 2 ways to run PhoenixGo engine
 
 Run the engine : `scripts/start.sh`
 
-`start.sh` will automatically detect the number of GPUs, run `mcts_main` with proper config file,
+`start.sh` will automatically detect the number of GPUs, run `mcts_main` 
+with proper config file,
 and write log files in directory `log`.
 
-You could also use a customized config file (.conf) by running `scripts/start.sh {config_path}`.
+You could also use a customized config file (.conf) by running 
+`scripts/start.sh {config_path}`.
 If you want to do that, see also [#configure-guide](#configure-guide).
 
 ##### 2) mcts_main : fully control
 
-If you want to fully control all the options of `mcts_main` (such as, changing log destination,
-or if start.sh is not compatible for your specific use), you can run directly `bazel-bin/mcts/mcts_main` instead.
+If you want to fully control all the options of `mcts_main` (such 
+as changing log destination, or if start.sh is not compatible for your 
+specific use), you can run directly `bazel-bin/mcts/mcts_main` instead.
 
 For a typical usage, these command line options should be added:
 - `--gtp` to enable GTP mode
-- `--config_path=replace/with/path/to/your/config/file` to specify the path to your config file
-- it is also needed to edit your config file (.conf) and manually add the full path to ckpt,
-see [FAQ question](/docs/FAQ.md/#a5-ckptzerockpt-20b-v1fp32plan-error-no-such-file-or-directory).
+- `--config_path=replace/with/path/to/your/config/file` to specify the 
+path to your config file
+- it is also needed to edit your config file (.conf) and manually add 
+the full path to ckpt, see 
+[FAQ question](/docs/FAQ.md/#a5-ckptzerockpt-20b-v1fp32plan-error-no-such-file-or-directory).
 You can also change options in config file, see [#configure-guide](#configure-guide).
-- for other command line options , see also [#command-line-options](#command-line-options) for details,
-or run `./mcts_main --help` . A copy of the `--help` is provided for your convenience [here](/docs/mcts-main-help.md)
+- for other command line options , see also [#command-line-options](#command-line-options) 
+for details, or run `./mcts_main --help` . A copy of the `--help` is provided for your 
+convenience [here](/docs/mcts-main-help.md)
 
 For example:
+
 ```
 $ bazel-bin/mcts/mcts_main --gtp --config_path=etc/mcts_1gpu.conf --logtostderr --v=0
 ```
 
 #### (Optional) : Distribute mode
 
-PhoenixGo support running with distributed workers, if there are GPUs on different machine.
+PhoenixGo support running with distributed workers, if there are GPUs 
+on different machine.
 
 Build the distribute worker:
 
@@ -133,8 +153,8 @@ Run `dist_zero_model_server` on distributed worker, **one for each GPU**.
 $ CUDA_VISIBLE_DEVICES={gpu} bazel-bin/dist/dist_zero_model_server --server_address="0.0.0.0:{port}" --logtostderr
 ```
 
-Fill `ip:port` of workers in the config file (`etc/mcts_dist.conf` is an example config for 32 workers),
-and run the distributed master:
+Fill `ip:port` of workers in the config file (`etc/mcts_dist.conf` is an 
+example config for 32 workers), and run the distributed master:
 
 ```
 $ scripts/start.sh etc/mcts_dist.conf
@@ -157,7 +177,8 @@ Same as Linux.
 
 ### On Windows
 
-Recommendation: See [FAQ question](/docs/FAQ.md/#a4-syntax-error-windows), to avoid syntax errors in config file and command line options on Windows.
+Recommendation: See [FAQ question](/docs/FAQ.md/#a4-syntax-error-windows), 
+to avoid syntax errors in config file and command line options on Windows.
 
 #### Use Pre-built Binary
 
@@ -167,13 +188,15 @@ The GPU version is much faster, but works only with compatible nvidia GPU.
 It supports this environment : 
 - CUDA 9.0 only
 - cudnn 7.1.x (x is any number) or lower for CUDA 9.0
-- no AVX, AVX2, AVX512 instructions supported in this release (so it is currently much slower than the linux version)
+- no AVX, AVX2, AVX512 instructions supported in this release (so it is 
+currently much slower than the linux version)
 - there is no TensorRT support on Windows
 
 Download and extract 
 [GPU version (Windows)](https://github.com/Tencent/PhoenixGo/releases/download/win-x64-gpu-v1/PhoenixGo-win-x64-gpu-v1.zip)
 
-Then follow the document included in the archive : how to install phoenixgo.pdf
+Then follow the document included in the archive : how to install 
+phoenixgo.pdf
 
 note : to support special features like CUDA 10.0 or AVX512 for example, 
 you can build your own build for windows, see [#79](https://github.com/Tencent/PhoenixGo/issues/79)
@@ -183,7 +206,8 @@ you can build your own build for windows, see [#79](https://github.com/Tencent/P
 If your GPU is not compatible, or if you don't want to use a GPU, you can download this 
 [CPU-only version (Windows)](https://github.com/Tencent/PhoenixGo/releases/download/win-x64-cpuonly-v1/PhoenixGo-win-x64-cpuonly-v1.zip), 
 
-Follow the document included in the archive : how to install phoenixgo.pdf
+Follow the document included in the archive : how to install 
+phoenixgo.pdf
 
 ## Configure Guide
 
@@ -246,7 +270,8 @@ Glog options are also supported:
 * `--v`: verbose log, `--v=1` for turning on some debug log, `--v=0` to turning off
 
 `mcts_main --help` for more command line options.
-A copy of the `--help` is provided for your convenience [here](/docs/mcts-main-help.md)
+A copy of the `--help` is provided for your convenience 
+[here](/docs/mcts-main-help.md)
 
 ## Analysis
 
@@ -264,6 +289,7 @@ move path winrate and continuation of moves analyzed, see
 
 ## FAQ
 
-You will find a lot of useful and important information, also most common problems and errors and how to fix them
+You will find a lot of useful and important information, also most common 
+problems and errors and how to fix them
 
 Please take time to read the [FAQ](/docs/FAQ.md)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -264,6 +264,38 @@ See: [#75](https://github.com/Tencent/PhoenixGo/issues/75) for how to build Tens
 
 ### Specific questions : bazel issues (linux and mac)
 
+#### B0. It is too hard to install bazel or start bazel
+
+You may find hard to download, install, run bazel
+
+If that's the case, and if you are using ubuntu or similar operating system, 
+you can use the all-in-one command below instead of the [main README](/README.md) 
+commands
+
+Read the [main README](/README.md) for explanations and instructions : 
+the all-in-one command below only saves you the time to find how to install 
+bazel and run all the bazel commands one by one, but you still have to 
+read the [main README](/README.md) for explanations
+
+The all-in-one command below has been tested to run successfully on ubuntu 
+16.04 LTS and 18.04 LTS
+
+`sudo apt-get -y install pkg-config zip g++ zlib1g-dev unzip python git && git clone https://github.com/Tencent/PhoenixGo.git && cd PhoenixGo && wget https://github.com/bazelbuild/bazel/releases/download/0.11.1/bazel-0.11.1-installer-linux-x86_64.sh && chmod +x bazel-0.11.1-installer-linux-x86_64.sh && ./bazel-0.11.1-installer-linux-x86_64.sh --user && echo 'export PATH="$PATH:$HOME/bin"' >> ~/.bashrc && source ~/.bashrc && sudo ldconfig && wget https://github.com/Tencent/PhoenixGo/releases/download/trained-network-20b-v1/trained-network-20b-v1.tar.gz && tar xvzf trained-network-20b-v1.tar.gz && sudo rm -r trained-network-20b-v1.tar.gz bazel-0.11.1-installer-linux-x86_64.sh && ./configure && bazel build //mcts:mcts_main && ls`
+
+This all-in-one command will : 
+
+- Download and install bazel and PhoenixGo dependencies for ubuntu and 
+similar systems (need to have apt-get)
+- Clone PhoenixGo from Tencent github
+- Download and install bazel 0.11.1
+- Do the post-install of bazel
+- Download and extract trained network (ckpt)
+- Cleanup : trained network archive and remove bazel installer
+- Run `./configure` : at this step, you have to confifure bazel 
+same as explained in [main README](/README.md)
+- When configure is finished, start building automatically, 
+same as explained in [main README](/README.md)
+
 #### B1. I am getting errors during bazel configure, bazel building, and/or running PhoenixGo engine
 
 If you built with bazel, see : 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -34,54 +34,20 @@ result is something like this (in this example there are 7000 simulations per mo
 [5489] stderr: I0116 15:55:09.910648  5489 mcts_debugger.cc:49] ========== debug info for 27th move(b) end   ==========
 ```
 
-It is also possible to develop all the tree by adding these lines to your config file :
+It is also possible to develop all the tree by adding these lines to 
+your config file :
 
 ```
 debugger {
-    print_tree_depth: 6
-    print_tree_width: 6
+    print_tree_depth: 20
+    print_tree_width: 3
 }
 ```
 
-In this example, a tree of 6 depth 6 width moves will be printed
-
+In this example, a tree of 20 depth 3 width moves will be printed
 #### A2.5 How to analyze/review one or many sgf file(s) with GoReviewPartner
 
-Support is still in testing, but so far these are the recommended settings to do use PhoenixGo with GoReviewPartner
-
-2 config files are provided to you using optimized settings for grp (GoReviewPartner)
-- with tensorrt (linux only) : [mcts_1gpu_grp.conf](/etc/mcts_1gpu_grp.conf)
-- without tensorrt (linux, mac, windows, gpu or cpu version) :
- [mcts_1gpu_notensorrt_grp.conf](/etc/mcts_1gpu_notensorrt_grp.conf)
- 
-note : it is also possible with multiple GPU, only the most common examples were shown here
-
-if you want to do the changes manually, you need to :
-
-in phoenixgo .conf config file :
-
-- disable all time settings in config file (set to `0`)
-- set time to unlimited (set timeout to 0 ms)
-- use simulations per move to have fixed computation per move (playouts), because it 
-is not needed to play fast since this is an analysis, unlimited time
-- for the same reason, set `enable background search` to 0 (disable pondering), because this is not a live game, 
-time settings are not needed and can cause conflicts
-- add debug width and height with `debugger` in config file, see previous FAQ question
-
-in grp (GoReviewPartner) settings :
-- it is easier to use one of the pre-made grp profile in config.ini (slightly modify them if needed)
-
-Don't forget to add paths in the config file as explained in 
-[FAQ question](/docs/FAQ.md/#a5-ckptzerockpt-20b-v1fp32plan-error-no-such-file-or-directory)
-
-If you're on windows, you need to also pay attention to the syntax too, 
-see [FAQ question](/docs/FAQ.md/#a4-syntax-error-windows)
-
-and run the mcts_main (not start.sh) with the needed parameters, 
-see an example 
-[here](https://github.com/wonderingabout/goreviewpartner/blob/config-profiles-phoenixgo/config.ini#L100-L116)
-
-also, see [#86](https://github.com/Tencent/PhoenixGo/issues/86) and [#99](https://github.com/pnprog/goreviewpartner/issues/99) for details
+See [this document](/docs/go-review-partner.md)
 
 #### A3. There are too much log.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -10,12 +10,16 @@ I0514 12:51:32.724236 14467 mcts_engine.cc:157] 1th move(b): dp, <b>winrate=44.1
 
 #### A2. Where is the PV (Analysis) ?
 
-It is possible to display the PV (variation of move path with continuation of the moves)
+It is possible to display the PV (variation of move path with 
+continuation of the moves)
 
-An easy way to do that is for example to increase verbose level, for example `--logtostderr --v=1` 
-(on windows the syntax is different, see [FAQ question](/docs/FAQ.md#a4-syntax-error-windows) for details
+An easy way to do that is for example to increase verbose level, 
+for example `--logtostderr --v=1` 
+(on windows the syntax is different, see 
+[FAQ question](/docs/FAQ.md#a4-syntax-error-windows) for details
 
-result is something like this (in this example there are 7000 simulations per move) :
+result is something like this (in this example there are 
+7000 simulations per move) :
 
 ```
 [5489] stderr: I0116 15:55:09.910559  5489 mcts_debugger.cc:43] ========== debug info for 27th move(b) begin ==========
@@ -45,6 +49,7 @@ debugger {
 ```
 
 In this example, a tree of 20 depth 3 width moves will be printed
+
 #### A2.5 How to analyze/review one or many sgf file(s) with GoReviewPartner
 
 See [this document](/docs/go-review-partner.md)
@@ -52,17 +57,20 @@ See [this document](/docs/go-review-partner.md)
 #### A3. There are too much log.
 
 Passing `--v=0` to `mcts_main` will turn off many debug log.
-Moreover, `--minloglevel=1` and `--minloglevel=2` could disable INFO log and WARNING log.
+Moreover, `--minloglevel=1` and `--minloglevel=2` could disable 
+INFO log and WARNING log.
 
-Or, if you just don't want to log to stderr, replace `--logtostderr` to `--log_dir={log_dir}`,
-then you could read your log from `{log_dir}/mcts_main.INFO`.
+Or, if you just don't want to log to stderr, replace `--logtostderr` 
+to `--log_dir={log_dir}`, then you could read your log from 
+`{log_dir}/mcts_main.INFO`.
 
 #### A4. Syntax error (Windows)
 
 For windows,
 - in config file, 
 
-you need to write path with `/` and not `\` in the config file .conf, for example : 
+you need to write path with `/` and not `\` in the config 
+file .conf, for example : 
 
 ```
 model_config {
@@ -72,11 +80,13 @@ model_config {
 - in cmd.exe,
 
 Here you need to write paths with `\` and not `/`. 
-Also command format on windows needs a space and not a `=`, for example : 
+Also command format on windows needs a space and not a `=`, for 
+example : 
 
 `mcts_main.exe --gtp --config_path C:\Users\amd2018\Downloads\PhoenixGo\etc\mcts_1gpu_notensorrt.conf`
 
-or if you want to show the PV, you need to remove the `=` too, for example : 
+or if you want to show the PV, you need to remove the `=` too, 
+for example : 
 
 `mcts_main.exe --gtp --config_path C:\Users\amd2018\Downloads\PhoenixGo\etc\mcts_1gpu_notensorrt.conf --logtostderr --v 1`
 
@@ -84,8 +94,9 @@ See next point below :
 
 #### A5. '"ckpt/zero.ckpt-20b-v1.FP32.PLAN"' error: No such file or directory
 
-This fix works for all systems : Linux, Mac, Windows, only the name of the ckpt file changes. 
-Modify your config file and write the full path of your ckpt directory, for example for linux : 
+This fix works for all systems : Linux, Mac, Windows, only the 
+name of the ckpt file changes. Modify your config file and write 
+the full path of your ckpt directory, for example for linux : 
 
 ```
 model_config {
@@ -99,7 +110,8 @@ model_config {
     train_dir: "c:/users/amd2018/Downloads/PhoenixGo/ckpt"
 ```
 
-if you use tensorRT (linux only, and compatible nvidia GPU only), also change path of tensorRT, for example :
+if you use tensorRT (linux only, and compatible nvidia GPU 
+only), also change path of tensorRT, for example :
 
 ```
 model_config {
@@ -111,7 +123,8 @@ model_config {
 
 #### A6. How to run with Sabaki?
 
-Setting GTP engine in Sabaki's menu: `Engines -> Manage Engines`, fill `Path` with path of `start.sh`.
+Setting GTP engine in Sabaki's menu: `Engines -> Manage Engines`, 
+fill `Path` with path of `start.sh`.
 Click `Engines -> Attach` to use the engine in your game.
 See also [#22](https://github.com/Tencent/PhoenixGo/issues/22).
 
@@ -121,24 +134,28 @@ Modify `timeout_ms_per_step` in your config file.
 
 #### A8. How make PhoenixGo think with constant time per move?
 
-Modify your config file. `early_stop`, `unstable_overtime`, `behind_overtime` and
-`time_control` are options that affect the search time, remove them if exist then
+Modify your config file. `early_stop`, `unstable_overtime`, 
+`behind_overtime` and`time_control` are options that affect the 
+search time, remove them if exist then
 each move will cost constant time/simulations.
 
 #### A9. What is the speed of the engine ? How can i make the engine think faster ?
 
-GPU is much faster to compute than CPU (but only nvidia GPU are supported)
+GPU is much faster to compute than CPU (but only nvidia GPU are 
+supported)
 
-TensorRT also increases significantly the speed of computation, but it is only 
-available for linux with a compatible nvidia GPU
+TensorRT also increases significantly the speed of computation, 
+but it is only available for linux with a compatible nvidia GPU
 
-Bigger batch size significantly increases the speed of the computation, but a bigger 
-batch size puts a bigger burden on the computation device (in case it is the GPU, 
-higher GPU load, higher VRAM usage), increase it only if your computation device can handle it
+Bigger batch size significantly increases the speed of the computation, 
+but a bigger batch size puts a bigger burden on the computation device 
+(in case it is the GPU, higher GPU load, higher VRAM usage), increase 
+it only if your computation device can handle it
 
-Some independent speed benchmarks have been run, they are available in the docs :
+Some independent speed benchmarks have been run, they are available 
+in the docs :
 
-- for GTX 1060 :  
+- for GTX 1060 : 
 [benchmark testing batch size from 4 to 64, tree size up to 2000M, max children up to 512, with tensorRT ON and OFF](/docs/benchmark-gtx1060.md)
 
 #### A10. GTP command `time_settings` doesn't work.
@@ -154,14 +171,18 @@ time_control {
 }
 ```
 
-`c_denom` and `c_maxply` are parameters for deciding how to use the "main time".
-`reserved_time` is how many seconds should reserved (for network latency) in "byo-yomi time".
+- `c_denom` and `c_maxply` are parameters for deciding how to use the 
+"main time".
+- `reserved_time` is how many seconds should reserved (for network latency) 
+in "byo-yomi time".
 
 #### A11. GTP command error : `invalid command`
 
-Some GTP commands are not supported by PhoenixGo, for example the `showboard` command. 
+Some GTP commands are not supported by PhoenixGo, for example the 
+`showboard` command. 
 
-To know supported GTP commands, start phoenixgo in GTP mode and enter the GTP command `list_commands`
+To know supported GTP commands, start phoenixgo in GTP mode and enter 
+the GTP command `list_commands`
 
 Result as of today is : 
 
@@ -184,28 +205,33 @@ get_debug_info
 get_last_move_debug_info
 ```
 
-If you use unsupported commands the engine will not work. Make sure your GTP tool 
-does not communicate with PhoenixGo with unsupported GTP commands.
+If you use unsupported commands the engine will not work. Make sure your 
+GTP tool does not communicate with PhoenixGo with unsupported GTP commands.
 
-For example, for [gtp2ogs](https://github.com/online-go/gtp2ogs) server command line GTP tool,
-you need to edit the file gtp2ogs.js and manually remove the existing `showboard` line if it 
+For example, for [gtp2ogs](https://github.com/online-go/gtp2ogs) server 
+command line GTP tool, you need to edit the file gtp2ogs.js and manually 
+remove the existing `showboard` line if it 
 is not already done, 
 [see](https://github.com/online-go/gtp2ogs/commit/d5ebdbbde259a97c5ae1aed0ec42a07c9fbb2dbf)
 
 #### A12. The game does not start, error : `unacceptable komi`
 
-With the default settings, the only komi value supported is only 7.5, with chinese rules only.
-If it is not automated, you need to manually set komi value to 7.5 with chinese rules.
+With the default settings, the only komi value supported is only 7.5, with 
+chinese rules only.If it is not automated, you need to manually set komi 
+value to 7.5 with chinese rules.
 
-If you want to implement PhoenixGo to a server where players play with different komi values 
-(for example 6.5, 0.5, 85.5, 200.5,etc), you need to force komi to 7.5 for the players. 
+If you want to implement PhoenixGo to a server where players play with 
+different komi values (for example 6.5, 0.5, 85.5, 200.5,etc), you need 
+to force komi to 7.5 for the players. 
 
-If it is not possible, there is a workaround you can use : configure you GTP tool to tell 
-PhoenixGo engine that the komi for the game is 7.5 even if it is not true
+If it is not possible, there is a workaround you can use : configure 
+you GTP tool to tell PhoenixGo engine that the komi for the game is 
+7.5 even if it is not true
 
-if you do that, the game will not be scored correctly because PhoenixGo will think that 
-the komi is 7.5 while the real komi is different, but at least PhoenixGo will be able to
-play the game. 
+if you do that, the game will not be scored correctly because PhoenixGo 
+will think that the komi is 7.5 while the real komi is different, but at 
+least PhoenixGo will be able to play the game.
+ 
 An example for [gtp2ogs](https://github.com/online-go/gtp2ogs) is provided 
 [here](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3A4-linux-optional-edit-gtp2ogs-js-file.md) 
 and [here](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3B4-windows-optional-edit-gtp2ogs-js-file.md)
@@ -214,19 +240,24 @@ and [here](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3
 
 ##### RTX cards (Turing) :
 
-- need CUDA 10.0 or higher (so currently, only linux is supported, or windows with your own building)
-- If you compile PhoenixGo, it has been tested to work on linux [here](/docs/tested-versions.md) 
-with CUDA 10.0, cudnn 7.4.2, ubuntu 18.04.
-- However currently there is no tensorRT support for PhoenixGo (RTX cards require tensorRT 5.x or more
-(and this also requires tensorflow 1.9 or more), which is currently not supported by PhoenixGo)
+- need CUDA 10.0 or higher (so currently, only linux is supported, or 
+windows with your own building)
+- If you compile PhoenixGo, it has been tested to work on linux 
+[here](/docs/tested-versions.md) with CUDA 10.0, cudnn 7.4.2, ubuntu 18.04.
+- However currently there is no tensorRT support for PhoenixGo 
+(RTX cards require tensorRT 5.x or more, and this also requires tensorflow 1.9 or more), 
+which is currently not supported by PhoenixGo)
 
 ##### Volta cards (Tesla V100 / Titan V and similar)
 
-- are compatible with cuda 9.0 and higher (it is recommended to use latest version when possible),
+- are compatible with cuda 9.0 and higher (it is recommended to 
+use latest version when possible),
 cudnn 7.1.x or higher (x is any number)
 - has been tested to work successfully on windows
-- to use TensorRT with V100, you need to manually build TensorRT model on V100.
-See: [#75](https://github.com/Tencent/PhoenixGo/issues/75) for how to build TensorRT model.
+- to use TensorRT with V100, you need to manually build TensorRT 
+model on V100.
+See: [#75](https://github.com/Tencent/PhoenixGo/issues/75) for 
+how to build TensorRT model.
 
 ### Specific questions : bazel issues (linux and mac)
 
@@ -234,24 +265,25 @@ See: [#75](https://github.com/Tencent/PhoenixGo/issues/75) for how to build Tens
 
 You may find hard to download, install, run bazel
 
-If that's the case, and if you are using ubuntu or similar operating system, 
-you can use the all-in-one command below instead of the [main README](/README.md) 
-commands
+If that's the case, and if you are using ubuntu or similar 
+operating system, 
+you can use the all-in-one command below instead of the 
+[main README](/README.md) commands
 
 Read the [main README](/README.md) for explanations and instructions : 
-the all-in-one command below only saves you the time to find how to install 
-bazel and run all the bazel commands one by one, but you still have to 
-read the [main README](/README.md) for explanations
+the all-in-one command below only saves you the time to find how to 
+install bazel and run all the bazel commands one by one, but you 
+still have to read the [main README](/README.md) for explanations
 
-The all-in-one command below has been tested to run successfully on ubuntu 
-16.04 LTS and 18.04 LTS
+The all-in-one command below has been tested to run successfully on 
+ubuntu 16.04 LTS and 18.04 LTS
 
 `sudo apt-get -y install pkg-config zip g++ zlib1g-dev unzip python git && git clone https://github.com/Tencent/PhoenixGo.git && cd PhoenixGo && wget https://github.com/bazelbuild/bazel/releases/download/0.11.1/bazel-0.11.1-installer-linux-x86_64.sh && chmod +x bazel-0.11.1-installer-linux-x86_64.sh && ./bazel-0.11.1-installer-linux-x86_64.sh --user && echo 'export PATH="$PATH:$HOME/bin"' >> ~/.bashrc && source ~/.bashrc && sudo ldconfig && wget https://github.com/Tencent/PhoenixGo/releases/download/trained-network-20b-v1/trained-network-20b-v1.tar.gz && tar xvzf trained-network-20b-v1.tar.gz && sudo rm -r trained-network-20b-v1.tar.gz bazel-0.11.1-installer-linux-x86_64.sh && ./configure && bazel build //mcts:mcts_main && ls`
 
 This all-in-one command will : 
 
-- Download and install bazel and PhoenixGo dependencies for ubuntu and 
-similar systems (need to have apt-get)
+- Download and install bazel and PhoenixGo dependencies for ubuntu 
+and similar systems (need to have apt-get)
 - Clone PhoenixGo from Tencent github
 - Download and install bazel 0.11.1
 - Do the post-install of bazel
@@ -267,15 +299,17 @@ same as explained in [main README](/README.md)
 If you built with bazel, see : 
 [Most common path errors during cuda/cudnn install and bazel configure](/docs/path-errors.md)
 
-See also [minimalist bazel configure](/docs/minimalist-bazel-configure.md) for an example 
-of build configure
+See also [minimalist bazel configure](/docs/minimalist-bazel-configure.md) 
+for an example of build configure
 
 If you are still getting errors, try using an older version of bazel. 
-For example bazel 0.20.0 is known to cause issues, and **bazel 0.11.1 is known good**
+For example bazel 0.20.0 is known to cause issues, and 
+**bazel 0.11.1 is known good**
 
 #### B2. The PhoenixGo and bazel folders are too big
 
-During the bazel building, there are many options that can are not required and can be disabled
+During the bazel building, there are many options that can are not 
+required and can be disabled
 
 This will reduce building time and will have smaller size after the building, 
 see [minimalist bazel configure](/docs/minimalist-bazel-configure.md) and 
@@ -287,13 +321,16 @@ Increasing batch size in the config file makes the engine compute faster,
 as explained earlier in 
 [FAQ question](/docs/FAQ.md/#6-what-is-the-speed-of-the-engine--how-can-i-make-the-engine-think-faster-)
 
-However, with default building, you cannot use batch size higher than 4 with tensorRT
-To increase batch size for example to 32 with tensorRT enabled, you need to build tensorrt model
-with bazel, See : [#75](https://github.com/Tencent/PhoenixGo/issues/75)
+However, with default building, you cannot use batch size higher than 4 
+with tensorRT
+To increase batch size for example to 32 with tensorRT enabled, you need 
+to build tensorrt model with bazel, See : 
+[#75](https://github.com/Tencent/PhoenixGo/issues/75)
 
 #### B4. How to remove entirely all PhoenixGo and bazel files and folders ?
 
-assuming you installed PhoenixGo in home directory (`~` or `/home/yourusername/`)
+assuming you installed PhoenixGo in home directory 
+(`~` or `/home/yourusername/`)
 
 ```
 # clean with bazel
@@ -303,4 +340,5 @@ sudo rm -rf ~/PhoenixGo
 # remove any remaining bazel file
 sudo rm -rf ~/.cache/bazel
 ```
-This will free a few GB (arround 3-6 GB depending on your installation settings)
+This will free a few GB (arround 3-6 GB depending on your installation 
+settings)

--- a/docs/benchmark-gtx1060.md
+++ b/docs/benchmark-gtx1060.md
@@ -1,16 +1,24 @@
 # Benchmark setup :
 
 ## setup
-- hardware : gtx 1060 6gb (1gpu, power limit set to 75W), ryzen r7 1700, 16gb ram
-- software : ubuntu 16.04 LTS, nvidia 384, cuda 9.0, cudnn 7.1.4, tensorrt 3.0.4, bazel 0.11.1
-- engine settings: unlimited time per move, all time management settings disabled in config file, all the rest is default settings
+- hardware : gtx 1060 6gb (1gpu, power limit set to 75W), ryzen r7 1700, 
+16gb ram
+- software : ubuntu 16.04 LTS, nvidia 384, cuda 9.0, cudnn 7.1.4, 
+tensorrt 3.0.4, bazel 0.11.1
+- engine settings: unlimited time per move, all time management settings 
+disabled in config file, all the rest is default settings
 
 ## methodology : 
-- most moves come from the same game played using [gtp2ogs](https://github.com/online-go/gtp2ogs), for few moves moves, copy paste stderr output
-- tensorRT is only used with batch size 4, because batch size of 5 and more is not supported with default settings, see : [#75](https://github.com/Tencent/PhoenixGo/issues/75)
+- most moves come from the same game played using 
+[gtp2ogs](https://github.com/online-go/gtp2ogs), for few moves moves, 
+copy paste stderr output
+- tensorRT is only used with batch size 4, because batch size of 5 and 
+more is not supported with default settings, see : 
+[#75](https://github.com/Tencent/PhoenixGo/issues/75)
 
 ## credits :
-credit for doing this tests go to [wonderingabout](https://github.com/wonderingabout)
+credit for doing this tests go to 
+[wonderingabout](https://github.com/wonderingabout)
 
 ## BATCH SIZE 4 :
 
@@ -341,11 +349,16 @@ stderr: 9th move(b): cf, winrate=49.737022%, N=2402, Q=-0.005260, p=0.512962, v=
 ```
 # PERCENTAGES EXPLANATION : 
 
-The speed gain number below is the time less needed to calculate a move, for example speed gain +12% = 12% less time to calculate a move as compared to batch size 4 = 27.5 seconds vs 30.5 seconds per move = 4 seconds difference out of 30.5 seconds 
+The speed gain number below is the time less needed to calculate a move, 
+for example speed gain +12% = 12% less time to calculate a move as compared 
+to batch size 4 = 27.5 seconds vs 30.5 seconds per move = 4 seconds 
+difference out of 30.5 seconds 
 
 # CONCLUSIONS for GTX 1060 : 
 
-- TensorRT can increase speed by arround 15%-20% on a GTX 1060 with batch size 4 (for bigger batch size with tensorRT, see [#75](https://github.com/Tencent/PhoenixGo/issues/75))
+- TensorRT can increase speed by arround 15%-20% on a GTX 1060 with batch size 4 
+(for bigger batch size with tensorRT, see 
+[#75](https://github.com/Tencent/PhoenixGo/issues/75))
 - bigger batch size significantly increases speed of the engine on a GTX 1060 :
      -> for batch size 8 , gain = +12%
      -> for batch size 16 , gain = +33%
@@ -354,7 +367,8 @@ The speed gain number below is the time less needed to calculate a move, for exa
 - Compute device (GPU or CPU) utilization is higher with higher batching
 - gtx 1060 is too weak to benefit higher batch sizes than 32
 - number of threads does not significantly change speed of the engine
-- tree size does not significantly change the speed of the engine (arround 5% more time with max tree size)
+- tree size does not significantly change the speed of the engine 
+(arround 5% more time with max tree size)
 
 # TO DO : 
 - i will try higher batch sizes with a Tesla V100 on windows 10

--- a/docs/go-review-partner.md
+++ b/docs/go-review-partner.md
@@ -1,0 +1,51 @@
+GoReviewPartner github page is [here](https://github.com/pnprog/goreviewpartner)
+
+Support is still in testing, but so far these are the recommended 
+settings to do use PhoenixGo with GoReviewPartner
+
+3 config files are provided to you using optimized settings for grp 
+(GoReviewPartner) :
+- GPU with tensorRT (linux only) : 
+[mcts_1gpu_grp.conf](/etc/mcts_1gpu_grp.conf)
+- GPU without tensorRT (linux, windows) : 
+[mcts_1gpu_notensorrt_grp.conf](/etc/mcts_1gpu_notensorrt_grp.conf)
+- CPU-only (linux, mac, windows), much slower : 
+[mcts_cpu_grp.conf](/etc/mcts_cpu_grp.conf)
+ 
+note : it is also possible with multiple GPU, only the most common 
+examples were shown here
+
+if you want to do the changes manually, you need to :
+
+in phoenixgo .conf config file :
+
+- disable all time settings in config file (set to `0`)
+- set time to unlimited (set timeout to 0 ms)
+- use simulations per move to have fixed computation per move (playouts), 
+because it is not needed to play fast since this is an analysis, 
+unlimited time
+- for the same reason, set `enable background search` to 0 (disable 
+pondering), because this is not a live game, time settings are not 
+needed and can cause conflicts
+- add debug width and height with `debugger` in config file, see 
+[FAQ question](/docs/FAQ.md/#a2-where-is-the-pv-analysis-)
+
+in grp (GoReviewPartner) settings :
+- it is easier to use one of the pre-made grp profile in config.ini 
+(slightly modify them if needed)
+
+- Don't forget to add paths in the config file as explained in 
+[FAQ question](/docs/FAQ.md/#a5-ckptzerockpt-20b-v1fp32plan-error-no-such-file-or-directory)
+
+- If you're on windows, you need to also pay attention to the syntax 
+too, for example on windows it is `--logtostderr --v 1` not 
+`--logtostderr --v=1` , see 
+[FAQ question](/docs/FAQ.md/#a4-syntax-error-windows) for details and 
+other differences
+
+- and run the mcts_main (not start.sh) with the needed parameters, 
+see an example 
+[here](https://github.com/wonderingabout/goreviewpartner/blob/config-profiles-phoenixgo/config.ini#L100-L116)
+
+also, see [#86](https://github.com/Tencent/PhoenixGo/issues/86) and 
+[#99](https://github.com/pnprog/goreviewpartner/issues/99) for details

--- a/docs/mcts-main-help.md
+++ b/docs/mcts-main-help.md
@@ -1,4 +1,6 @@
-For your convenience, a copy of  `./mcts_main --help` output is provided to you below
+For your convenience, a copy of  `./mcts_main --help` output is provided to 
+you below 
+
 Date is January 2019, so it may be outdated if newer versions are released
 
 `./mcts_main --help`

--- a/docs/minimalist-bazel-configure.md
+++ b/docs/minimalist-bazel-configure.md
@@ -1,8 +1,11 @@
-To reduce phoenixgo size and building time, it is wise to remove all the uneeded options during the bazel `./configure` , as was discussed here : [#76](https://github.com/Tencent/PhoenixGo/issues/76)
+To reduce phoenixgo size and building time, it is wise to remove all 
+the uneeded options during the bazel `./configure` , as was discussed 
+here : [#76](https://github.com/Tencent/PhoenixGo/issues/76)
 
 This is an example of minimalist options that you can use : 
 
-note : if you have trouble with path configurations, see [path-errors](/docs/path-errors.md)
+note : if you have trouble with path configurations, see 
+[path-errors](/docs/path-errors.md)
 
 ```
 Please specify the location of python. [Default is /usr/bin/python]: 

--- a/docs/path-errors.md
+++ b/docs/path-errors.md
@@ -1,14 +1,23 @@
-In the example below, ubuntu 16.04 LTS is used with cuda 9.0 (deb install) ,
-cudnn 7.0.5 (deb install), tensorrt 3.0.4 (deb install), as well as bazel 0.18.1 (.sh file install) (0.11.1 also works)
+In the example below, ubuntu 16.04 LTS is used with cuda 9.0 (deb install), 
+cudnn 7.0.5 (deb install), tensorrt 3.0.4 (deb install), as well as bazel 0.18.1 
+(.sh file install) (0.11.1 also works)
 
-Other linux distributions with nvidia tar install are possible too (some other versions have been [tested here](/docs/tested-versions.md)), but it is easier to do it like that, and remember that this is just an example. The settings below have been tested to be working and to fix most common path issues, and are shown as an interactive help :
+Other linux distributions with nvidia tar install are possible too 
+(some other versions have been [tested here](/docs/tested-versions.md)), 
+but it is easier to do it like that, and remember that this is just an example. 
+The settings below have been tested to be working and to fix most common path 
+issues, and are shown as an interactive help :
 
 ## 1) post-install of cuda : do the path exports
 
-After cuda 9.0 deb install and cudnn 7.0.5 deb are installed successfully, one post install step is needed : add the path to cuda-9.0. Here we do an all in once step by also including the path of cudnn even if cudnn is not installed yet.
+After cuda 9.0 deb install and cudnn 7.0.5 deb are installed successfully, 
+one post install step is needed : add the path to cuda-9.0. Here we do an 
+all in once step by also including the path of cudnn even if cudnn is not 
+installed yet.
 
-The `export` command alone adds the path during current boot, but the changes will be lost after reboot.
-This is why we will add paths permanently using `bashrc`
+The `export` command alone adds the path during current boot, but the 
+changes will be lost after reboot. This is why we will add paths permanently 
+using `bashrc`
 
 ### bashrc
 
@@ -16,7 +25,8 @@ edit bashrc file :
 
 `sudo nano ~/.bashrc`
 
-you need to add the lines below at the end of the bashrc file (using nano, or the text editor of your choice) :
+you need to add the lines below at the end of the bashrc file (using nano, 
+or the text editor of your choice) :
 
 ```
 # add paths for cuda-9.0
@@ -28,7 +38,8 @@ export CUDA_INSTALL_DIR=/usr/local/cuda
 export CUDNN_INSTALL_DIR=/usr/local/cuda
 ```
 
-With nano, after editing is finished, save and exit with `Ctrl+X` + then press `y` + then press ENTER key.
+With nano, after editing is finished, save and exit with `Ctrl+X` + 
+then press `y` + then press ENTER key.
 
 Now update bashrc file :
 
@@ -47,7 +58,8 @@ Built on Fri_Sep__1_21:08:03_CDT_2017
 Cuda compilation tools, release 9.0, V9.0.176
 ```
 
-you can also check if cuda installation is a success with `cat /proc/driver/nvidia/version`
+you can also check if cuda installation is a success with 
+`cat /proc/driver/nvidia/version`
 
 should display something like this :
 
@@ -56,11 +68,14 @@ NVRM version: NVIDIA UNIX x86_64 Kernel Module  384.130  Wed Mar 21 03:37:26 PDT
 GCC version:  gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.10)
 ```
 
-If you need help of how to install the deb files of cuda 9.0, cudnn 7.0.5, and tensorrt 3.0.4 for ubuntu 16.04, you can go here [@wonderingabout](https://github.com/wonderingabout/nvidia-archives)
+If you need help of how to install the deb files of cuda 9.0, cudnn 7.0.5, 
+and tensorrt 3.0.4 for ubuntu 16.04, you can go here 
+[@wonderingabout](https://github.com/wonderingabout/nvidia-archives)
 
 ## 1b) after cuda 9.0 and cudnn 7.0.5 deb installs, test your cudnn
 
-run a test to see if your install works by compiling and runing a cudnn code sample :
+run a test to see if your install works by compiling and runing a 
+cudnn code sample :
 
 ```
 cp -r /usr/src/cudnn_samples_v7/ ~ && cd ~/cudnn_samples_v7/mnistCUDNN && make clean && make && ./mnistCUDNN
@@ -90,11 +105,17 @@ It should now display all the cuda and cudnn paths same as above.
 
 ## 3) during bazel compile, this is the paths you need to put
 
-Press ENTER for every prompt to choose default settings (or `n` if you dont want a setting), except for these : 
+Press ENTER for every prompt to choose default settings 
+(or `n` if you dont want a setting), except for these : 
 
-- CUDA : choose `y` , version `9.0` if it is not default (then leave path to default by pressing ENTER)
-- cudnn : choose version `7.0.5` (then leave default path by pressing ENTER)
-- if you want to use tensorrt do `y` and press enter to keep default path if you did tensorrt deb install, but for tar install you need to setup manually your path, as you can see here [@wonderingabout](https://github.com/wonderingabout/nvidia-archives)
+- CUDA : choose `y` , version `9.0` if it is not default 
+(then leave path to default by pressing ENTER)
+- cudnn : choose version `7.0.5` 
+(then leave default path by pressing ENTER)
+- if you want to use tensorrt do `y` and press enter to keep default 
+path if you did tensorrt deb install, but for tar install you need to setup 
+manually your path, as you can see here 
+[@wonderingabout](https://github.com/wonderingabout/nvidia-archives)
 
 same as below :
 
@@ -116,13 +137,20 @@ TensorRT support will be enabled for TensorFlow.
 Please specify the location where TensorRT is installed. [Default is /usr/lib/x86_64-linux-gnu]:
 ```
 
-note : (tar install is needed to install `.whl` to inrcease max batch size with tensorrt), see : [#75](https://github.com/Tencent/PhoenixGo/issues/75)
+note : (tar install is needed to install `.whl` to inrcease max batch size 
+with tensorrt), see : [#75](https://github.com/Tencent/PhoenixGo/issues/75)
 
 Final words :
 
-Remember that these settings are just an example, other settings or package versions or linux distributions are possible too, but this example has been tested to successfully work on ubuntu 16.04 LTS with deb install of cuda 9.0, deb install of cudnn 7.0.5, deb install of tensorrt 3.0.4, as well as .sh file install of bazel 0.11.1
+Remember that these settings are just an example, other settings or 
+package versions or linux distributions are possible too, but this 
+example has been tested to successfully work on ubuntu 16.04 LTS with 
+deb install of cuda 9.0, deb install of cudnn 7.0.5, deb install of 
+tensorrt 3.0.4, as well as .sh file install of bazel 0.11.1
 
-They are provided as a general help for linux compile and run, they are not an obligatory method to use, but will hopefully make using PhoenixGo on linux systems easier
+They are provided as a general help for linux compile and run, they 
+are not an obligatory method to use, but will hopefully make using 
+PhoenixGo on linux systems easier
 
 credits : 
 - [mishra.thedeepak](https://medium.com/@mishra.thedeepak/cuda-and-cudnn-installation-for-tensorflow-gpu-79beebb356d2)

--- a/docs/tested-versions.md
+++ b/docs/tested-versions.md
@@ -1,4 +1,5 @@
-Below is a list of other versions of cuda/cudnn/tensorrt/bazel tar/deb tested by independent contributors, that work with PhoenixGo AI
+Below is a list of other versions of cuda/cudnn/tensorrt/bazel tar/deb 
+tested by independent contributors, that work with PhoenixGo AI
 
 compatibility for tensorrt : 
 - 3.0.4 requires cudnn 7.0.x and +
@@ -10,13 +11,20 @@ compatibility for tensorrt :
 #### works
 - bazel : 0.11.1 , 0.17.2 , 0.18.1
 - ubuntu : 16.04 , 18.04 
-- cuda : 9.0 deb , 10.0 deb (10.0 deb ubuntu 18.04 is with cudnn 7.4.x deb and no tensorrt), 9.0 for windows 10 and windows server 2016
-- cudnn : 7.0.5 deb, 7.1.4 deb , 7.4.2 deb, 7.1.4 on windows 10 with cuda 9.0
+- cuda : 9.0 deb , 10.0 deb (10.0 deb ubuntu 18.04 is with cudnn 
+7.4.x deb and no tensorrt), 9.0 for windows 10 and windows server 
+2016
+- cudnn : 7.0.5 deb, 7.1.4 deb , 7.4.2 deb, 7.1.4 on windows 10 
+with cuda 9.0
 - tensorrt : 3.0.4 deb , 3.0.4 tar
-- pycuda : for tensorrt tar, pycuda with pyhton 2.7 (needs [a modification](http://0561blue.tistory.com/m/13?category=627413), pycuda specific issue, see [#75](https://github.com/Tencent/PhoenixGo/issues/75)
+- pycuda : for tensorrt tar, pycuda with pyhton 2.7 
+(needs [a modification](http://0561blue.tistory.com/m/13?category=627413), 
+pycuda specific issue, see [#75](https://github.com/Tencent/PhoenixGo/issues/75)
 
 #### does NOT work : 
 - cuda on windows 10 : cuda 10.0
-- cudnn for windows 10 : cudnn 7.4.x for cuda 10.0 , cudnn 7.4.x for cuda 9.0
+- cudnn for windows 10 : cudnn 7.4.x for cuda 10.0 , cudnn 7.4.x for 
+cuda 9.0
 - tensorrt : 4.x deb , 4.x tar, 5.x deb
-- bazel : 0.19.x and superior (needs [a modification](https://github.com/tensorflow/tensorflow/issues/23401))
+- bazel : 0.19.x and superior 
+(needs [a modification](https://github.com/tensorflow/tensorflow/issues/23401))

--- a/etc/mcts_cpu_grp.conf
+++ b/etc/mcts_cpu_grp.conf
@@ -1,0 +1,49 @@
+num_eval_threads: 1
+num_search_threads: 8
+max_children_per_node: 64
+max_search_tree_size: 400000000
+timeout_ms_per_step: 0
+max_simulations_per_step: 1600
+eval_batch_size: 4
+eval_wait_batch_timeout_us: 100
+model_config {
+    train_dir: "ckpt"
+}
+c_puct: 2.5
+virtual_loss: 1.0
+enable_resign: 1
+v_resign: -0.9
+enable_dirichlet_noise: 0
+dirichlet_noise_alpha: 0.03
+dirichlet_noise_ratio:  0.25
+monitor_log_every_ms: 0
+get_best_move_mode: 0
+enable_background_search: 0
+enable_policy_temperature: 0
+policy_temperature: 0.67
+inherit_default_act: 1
+debugger {
+    print_tree_depth: 20
+    print_tree_width: 3
+}
+early_stop {
+    enable: 0
+    check_every_ms: 100
+    sims_factor: 1.0
+    sims_threshold: 2000
+}
+unstable_overtime {
+    enable: 0
+    time_factor: 0.3
+}
+behind_overtime {
+    enable: 0
+    act_threshold: 0.0
+    time_factor: 0.3
+}
+time_control {
+    enable: 0
+    c_denom: 20
+    c_maxply: 40
+    reserved_time: 1.0
+}


### PR DESCRIPTION
this is a small PR in continuation of #73 

general look : https://github.com/wonderingabout/PhoenixGo/tree/faqv3-bazel-master

easy review : https://github.com/Tencent/PhoenixGo/pull/88/files?utf8=%E2%9C%93&diff=split


main changes : 

- GoReviewPartner : most users may not be interested about GoReviewPartner, so moving it 
out of the FAQ in a separate doc,
also fixing some details
and adding a cpu-only grp .conf file

- all-in-one-command to install bazel
many users have trouble to install and start bazel, and may not want to spend time to find the information of how to do it,
so, since we know how to do it, pushing again this very useful command, but in a FAQ question this time (to keep README small, link only)

- add " Download and Install Bazel" in readme
this is the first step before starting to build with bazel after all
i hope it will be clearer for the confused new users

- word wrap in all docs and in readme
similar to what is done and good practices in all github projects

- minor other small fixes

@wodesuck i hope you will find this one easier to review, thanks again for your time :+1: 
i am looking forward to improve PhoenixGo more :1st_place_medal: 
