### PR TITLE
Faqv4 bazel master : add benchmark Tesla V100 + minor readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For PhoenixGo, bazel (**0.11.1 is known-good**), read
 
 If you have issues on how to install or start bazel, you may want 
 to try this all-in-one command line for easier building instead, see
-[FAQ question](/docs/FAQ.md#b0-it-is-too-hard-to-install-bazel-or-run-the-bazel-commands)
+[FAQ question](/docs/FAQ.md#b0-it-is-too-hard-to-install-bazel-or-start-bazel)
 
 #### Building PhoenixGo with Bazel
 
@@ -120,10 +120,12 @@ path to your config file
 - it is also needed to edit your config file (.conf) and manually add 
 the full path to ckpt, see 
 [FAQ question](/docs/FAQ.md/#a5-ckptzerockpt-20b-v1fp32plan-error-no-such-file-or-directory).
-You can also change options in config file, see [#configure-guide](#configure-guide).
-- for other command line options , see also [#command-line-options](#command-line-options) 
-for details, or run `./mcts_main --help` . A copy of the `--help` is provided for your 
-convenience [here](/docs/mcts-main-help.md)
+You can also change options in config file, see 
+[#configure-guide](#configure-guide).
+- for other command line options , see also 
+[#command-line-options](#command-line-options) 
+for details, or run `./mcts_main --help` . A copy of the `--help` is 
+provided for your convenience [here](/docs/mcts-main-help.md)
 
 For example:
 
@@ -194,7 +196,8 @@ Then follow the document included in the archive : how to install
 phoenixgo.pdf
 
 note : to support special features like CUDA 10.0 or AVX512 for example, 
-you can build your own build for windows, see [#79](https://github.com/Tencent/PhoenixGo/issues/79)
+you can build your own build for windows, see 
+[#79](https://github.com/Tencent/PhoenixGo/issues/79)
 
 ##### CPU-only version : 
 
@@ -251,7 +254,8 @@ Read `mcts/mcts_config.proto` for more config options.
 
 * `--config_path`: path of config file
 * `--gtp`: run as a GTP engine, if disable, gen next move only
-* `--init_moves`: initial moves on the go board, for example usage, see [#83](https://github.com/Tencent/PhoenixGo/issues/83)
+* `--init_moves`: initial moves on the go board, for example usage, see 
+[FAQ question](/docs/FAQ.md/#a8-how-make-phoenixgo-start-at-other-position-at-move-1-and-after)
 * `--gpu_list`: override `gpu_list` in config file
 * `--listen_port`: work with `--gtp`, run gtp engine on port in TCP protocol
 * `--allow_ip`: work with `--listen_port`, list of client ip allowed to connect
@@ -270,17 +274,17 @@ A copy of the `--help` is provided for your convenience
 
 ## Analysis
 
-It is possible to analyse .sgf files using analysis tools such as :
+For analysis purpose, an easy way to display the PV (variations for 
+main move path) is `--logtostderr --v=1` which will display the main 
+move path winrate and continuation of moves analyzed, see 
+[FAQ question](/docs/FAQ.md/#a2-where-is-the-pv-analysis-) for details
+
+It is also possible to analyse .sgf files using analysis tools such as :
 - [GoReviewPartner](https://github.com/pnprog/goreviewpartner) : 
 an automated tool to analyse and/or review one or many .sgf files 
 (saved as .rsgf file). It supports PhoenixGo and other bots. See 
 [FAQ question](/docs/FAQ.md/#a25-how-to-analyzereview-one-or-many-sgf-files-with-goreviewpartner) 
 for details
-
-For analysis purpose, an easy way to display the PV (variations for 
-main move path) is `--logtostderr --v=1` which will display the main 
-move path winrate and continuation of moves analyzed, see 
-[FAQ question](/docs/FAQ.md/#a2-where-is-the-pv-analysis-) for details
 
 ## FAQ
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -11,31 +11,34 @@ I0514 12:51:32.724236 14467 mcts_engine.cc:157] 1th move(b): dp, <b>winrate=44.1
 #### A2. Where is the PV (Analysis) ?
 
 It is possible to display the PV (variation of move path with 
-continuation of the moves)
+continuation of the moves : `main move path`, `second move path`,
+`third move path`)
 
 An easy way to do that is for example to increase verbose level, 
 for example `--logtostderr --v=1` 
-(on windows the syntax is different, see 
+(for windows the syntax is different, see 
 [FAQ question](/docs/FAQ.md#a4-syntax-error-windows) for details
 
-result is something like this (in this example there are 
-7000 simulations per move) :
+result is something like this (there are 30000 simulations 
+in that example) :
 
 ```
-[5489] stderr: I0116 15:55:09.910559  5489 mcts_debugger.cc:43] ========== debug info for 27th move(b) begin ==========
-[5489] stderr: I0116 15:55:09.910596  5489 mcts_debugger.cc:44] main move path: mg(6482,-0.12,0.89,-0.09),lf(6349,0.12,0.88,0.08),lg(3006,-0.12,0.53,-0.12),kf(2654,0.14,0.63,-0.01),qh(941,-0.11,0.16,-0.11),qi(785,0.12,0.77,0.13),rh(784,-0.12,0.98,-0.13),pi(538,0.13,0.52,0.09),rg(445,-0.12,0.73,-0.18),og(365,0.13,0.76,0.15),pf(363,-0.13,0.98,-0.19),rd(159,0.10,0.52,0.14),ql(47,-0.06,0.21,-0.18),oq(19,0.04,0.36,-0.03),nq(12,-0.05,0.58,-0.07),pq(11,0.05,0.97,0.03),np(10,-0.05,0.79,-0.12),qn(9,0.04,0.84,0.03),ol(8,-0.05,0.82,-0.05),fc(6,0.07,0.60,0.06),kg(4,-0.06,0.42,-0.13),jf(2,-0.02,0.53,0.02),jg(1,0.05,0.45,0.05),cg(0,-nan,0.00,nan)
-[5489] stderr: I0116 15:55:09.910604  5489 mcts_debugger.cc:139] mg: N=6482, W=-757.077, Q=-0.116797, p=0.887549, v=-0.0932888
-[5489] stderr: I0116 15:55:09.910609  5489 mcts_debugger.cc:139] oh: N=262, W=-38.6935, Q=-0.147685, p=0.0710239, v=-0.137658
-[5489] stderr: I0116 15:55:09.910614  5489 mcts_debugger.cc:139] qh: N=38, W=-6.34157, Q=-0.166883, p=0.0139782, v=-0.144544
-[5489] stderr: I0116 15:55:09.910617  5489 mcts_debugger.cc:139] nb: N=1, W=-0.294998, Q=-0.294998, p=0.000126838, v=-0.295011
-[5489] stderr: I0116 15:55:09.910621  5489 mcts_debugger.cc:139] lc: N=1, W=-0.354553, Q=-0.354553, p=0.000164667, v=-0.354567
-[5489] stderr: I0116 15:55:09.910626  5489 mcts_debugger.cc:139] ob: N=1, W=-0.28775, Q=-0.28775, p=0.000373717, v=-0.287757
-[5489] stderr: I0116 15:55:09.910630  5489 mcts_debugger.cc:139] oj: N=1, W=-0.359818, Q=-0.359818, p=0.000128213, v=-0.359819
-[5489] stderr: I0116 15:55:09.910634  5489 mcts_debugger.cc:139] rc: N=1, W=-0.30574, Q=-0.30574, p=0.000222438, v=-0.305748
-[5489] stderr: I0116 15:55:09.910639  5489 mcts_debugger.cc:139] oc: N=1, W=-0.281403, Q=-0.281403, p=0.000368299, v=-0.281408
-[5489] stderr: I0116 15:55:09.910642  5489 mcts_debugger.cc:139] qd: N=1, W=-0.288712, Q=-0.288712, p=0.00012808, v=-0.288724
-[5489] stderr: I0116 15:55:09.910646  5489 mcts_debugger.cc:48] model global step: 639200
-[5489] stderr: I0116 15:55:09.910648  5489 mcts_debugger.cc:49] ========== debug info for 27th move(b) end   ==========
+mcts_debugger.cc:43] ========== debug info for 1th move(b) begin ==========
+mcts_debugger.cc:44] main move path: dd(2959,-0.12,0.08,-0.11),pp(762,0.12,0.22,0.11),dq(142,-0.12,0.16,-0.12),pd(107,0.12,0.70,0.11),nq(21,-0.12,0.17,-0.13),co(6,0.13,0.24,0.14),fp(3,-0.13,0.36,-0.13),cc(2,0.13,0.31,0.11),cd(1,-0.14,0.92,-0.14),dk(0,-nan,0.00,nan)
+mcts_debugger.cc:45] second move path: pd(2930,-0.12,0.08,-0.11),dp(745,0.12,0.22,0.11),cd(136,-0.12,0.16,-0.12),pp(102,0.12,0.70,0.11),cn(19,-0.12,0.16,-0.13),ec(6,0.13,0.24,0.13),df(3,-0.13,0.36,-0.11),qc(2,0.13,0.32,0.12),pc(1,-0.14,0.90,-0.14),dj(0,-nan,0.00,nan)
+mcts_debugger.cc:46] third move path: dp(2911,-0.12,0.08,-0.12),pd(765,0.12,0.23,0.10),qp(144,-0.12,0.16,-0.12),dd(109,0.12,0.70,0.11),qf(20,-0.12,0.16,-0.12),oq(6,0.13,0.23,0.12),pn(3,-0.13,0.36,-0.13),cq(2,0.13,0.31,0.13),dq(1,-0.14,0.91,-0.14),im(0,-nan,0.00,nan)
+mcts_debugger.cc:140] dd: N=2959, W=-346.395, Q=-0.117065, p=0.0802264, v=-0.113951
+mcts_debugger.cc:140] pd: N=2930, W=-343.235, Q=-0.117145, p=0.0792342, v=-0.113951
+mcts_debugger.cc:140] dp: N=2911, W=-340.83, Q=-0.117083, p=0.0783167, v=-0.116534
+mcts_debugger.cc:140] pp: N=2840, W=-332.817, Q=-0.117189, p=0.0770947, v=-0.120119
+mcts_debugger.cc:140] dq: N=2363, W=-279.487, Q=-0.118277, p=0.0700366, v=-0.117204
+mcts_debugger.cc:140] cd: N=2330, W=-275.263, Q=-0.118138, p=0.0683769, v=-0.116526
+mcts_debugger.cc:140] qp: N=2321, W=-273.97, Q=-0.118039, p=0.0676945, v=-0.12072
+mcts_debugger.cc:140] dc: N=2295, W=-271.415, Q=-0.118264, p=0.0683262, v=-0.116526
+mcts_debugger.cc:140] cp: N=2262, W=-267.68, Q=-0.118338, p=0.0675763, v=-0.12072
+mcts_debugger.cc:140] qd: N=2261, W=-268.092, Q=-0.118572, p=0.0687082, v=-0.118771
+mcts_debugger.cc:50] model global step: 639200
+mcts_debugger.cc:51] ========== debug info for 1th move(b) end   ==========
 ```
 
 It is also possible to develop all the tree by adding these lines to 
@@ -69,8 +72,8 @@ to `--log_dir={log_dir}`, then you could read your log from
 For windows,
 - in config file, 
 
-you need to write path with `/` and not `\` in the config 
-file .conf, for example : 
+you need **to write path with `/` and not `\` in the config file** 
+ .conf, for example : 
 
 ```
 model_config {
@@ -79,8 +82,10 @@ model_config {
 
 - in cmd.exe,
 
-Here you need to write paths with `\` and not `/`. 
-Also command format on windows needs a space and not a `=`, for 
+Here you need to **write paths with `\` and not `/` in command line**, 
+it is the opposite for command line. 
+
+Also command format **on command line needs a space and not a `=`**, for 
 example : 
 
 `mcts_main.exe --gtp --config_path C:\Users\amd2018\Downloads\PhoenixGo\etc\mcts_1gpu_notensorrt.conf`
@@ -132,12 +137,36 @@ See also [#22](https://github.com/Tencent/PhoenixGo/issues/22).
 
 Modify `timeout_ms_per_step` in your config file.
 
-#### A8. How make PhoenixGo think with constant time per move?
+For example `5000` is 5 seconds per move.
+
+#### A7.5. How make PhoenixGo think with constant time per move?
 
 Modify your config file. `early_stop`, `unstable_overtime`, 
 `behind_overtime` and`time_control` are options that affect the 
 search time, remove them if exist then
 each move will cost constant time/simulations.
+
+#### A8. How make PhoenixGo start at other position at move 1 and after
+
+- In command line, you can add the command flag `--init_moves`, 
+for example :
+
+```
+$ bazel-bin/mcts/mcts_main --gtp --config_path=etc/mcts_1gpu.conf --logtostderr --v=1 --init_moves="dp,zz,qe,zz,dd,qp,zz,qg,zz,pc,oq,pn,od,pd,pe,oe,of,ne,pg,md,pi"
+```
+
+In this example we start at move 22, see also 
+[#83](https://github.com/Tencent/PhoenixGo/issues/83) for 
+screenshots
+
+For windows the syntax is different, see 
+[FAQ question](/docs/FAQ.md/#a4-syntax-error-windows) for details
+
+You can also use the GTP command `undo` to cancel last move only, 
+the undo command can be repeated many times if want
+
+- In non command line, you can open your .sgf file in a sgf 
+viewer like Sabaki for example
 
 #### A9. What is the speed of the engine ? How can i make the engine think faster ?
 
@@ -147,16 +176,20 @@ supported)
 TensorRT also increases significantly the speed of computation, 
 but it is only available for linux with a compatible nvidia GPU
 
-Bigger batch size significantly increases the speed of the computation, 
-but a bigger batch size puts a bigger burden on the computation device 
-(in case it is the GPU, higher GPU load, higher VRAM usage), increase 
-it only if your computation device can handle it
+Bigger batch size significantly increases the speed of the 
+computation, but a bigger batch size puts a bigger burden on the 
+computation device (in case it is the GPU, higher GPU load, higher 
+VRAM usage), increase it only if your computation device can handle 
+it
 
 Some independent speed benchmarks have been run, they are available 
 in the docs :
 
-- for GTX 1060 : 
-[benchmark testing batch size from 4 to 64, tree size up to 2000M, max children up to 512, with tensorRT ON and OFF](/docs/benchmark-gtx1060.md)
+- for GTX 1060 75W (75w power limit) : 
+[benchmark testing batch size from 4 to 64, tree size up to 2000M, max children up to 512, with tensorRT ON and OFF](/docs/benchmark-gtx1060-75w.md)
+
+- for Tesla V100 :
+[benchmark testing batch size from 4 to 128, 4 to 12 vcpu, no tensorrt](/docs/benchmark-teslaV100.md)
 
 #### A10. GTP command `time_settings` doesn't work.
 
@@ -203,6 +236,7 @@ genmove
 final_score
 get_debug_info
 get_last_move_debug_info
+undo
 ```
 
 If you use unsupported commands the engine will not work. Make sure your 
@@ -231,10 +265,6 @@ you GTP tool to tell PhoenixGo engine that the komi for the game is
 if you do that, the game will not be scored correctly because PhoenixGo 
 will think that the komi is 7.5 while the real komi is different, but at 
 least PhoenixGo will be able to play the game.
- 
-An example for [gtp2ogs](https://github.com/online-go/gtp2ogs) is provided 
-[here](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3A4-linux-optional-edit-gtp2ogs-js-file.md) 
-and [here](https://github.com/wonderingabout/gtp2ogs-tutorial/blob/master/docs/3B4-windows-optional-edit-gtp2ogs-js-file.md)
 
 #### A13. I have a nvidia RTX card (Turing) or Tesla V100/Titan V (Volta), is it compatible ?
 
@@ -252,12 +282,15 @@ which is currently not supported by PhoenixGo)
 
 - are compatible with cuda 9.0 and higher (it is recommended to 
 use latest version when possible),
-cudnn 7.1.x or higher (x is any number)
+cudnn 7.1.x and higher (x is any number)
 - has been tested to work successfully on windows
 - to use TensorRT with V100, you need to manually build TensorRT 
 model on V100.
 See: [#75](https://github.com/Tencent/PhoenixGo/issues/75) for 
 how to build TensorRT model.
+
+You can find a speed benchmark for Tesla V100 in 
+[FAQ question](/docs/FAQ.md#a9-what-is-the-speed-of-the-engine--how-can-i-make-the-engine-think-faster-)
 
 ### Specific questions : bazel issues (linux and mac)
 

--- a/docs/benchmark-gtx1060-75w.md
+++ b/docs/benchmark-gtx1060-75w.md
@@ -1,8 +1,8 @@
 # Benchmark setup :
 
 ## setup
-- hardware : gtx 1060 6gb (1gpu, power limit set to 75W), ryzen r7 1700, 
-16gb ram
+- hardware : gtx 1060 6gb 75W (1gpu, power limit set to 75W), 
+ryzen r7 1700, 16gb ram
 - software : ubuntu 16.04 LTS, nvidia 384, cuda 9.0, cudnn 7.1.4, 
 tensorrt 3.0.4, bazel 0.11.1
 - engine settings: unlimited time per move, all time management settings 
@@ -22,12 +22,12 @@ credit for doing this tests go to
 
 ## BATCH SIZE 4 :
 
-batch size 4
-tensorrt : OFF
-8 threads
-children : 64
-400M tree size 
-4000 sims
+- batch size 4
+- tensorrt : OFF
+- 8 threads
+- children : 64
+- 400M tree size 
+- 4000 sims
 
 ```
 stderr: 25th move(b): dm, winrate=63.730274%, N=2305, Q=0.274606, p=0.400499, v=0.184802, cost 30390.792969ms, sims=4008, height=22, avg_height=7.976195, global_step=639200
@@ -35,12 +35,12 @@ stderr: 27th move(b): dl, winrate=63.091705%, N=4244, Q=0.261834, p=0.566229, v=
 ```
 
 
-batch size 4
-tensorrt : ON
-8 threads
-children : 64
-400M tree size 
-4000 sims
+- batch size 4
+- tensorrt : ON
+- 8 threads
+- children : 64
+- 400M tree size 
+- 4000 sims
 
 ```
 stderr: 21th move(b): cc, winrate=51.277012%, N=3998, Q=0.025540, p=0.965418, v=0.010357, cost 26055.263672ms, sims=4008, height=25, avg_height=6.226337, global_step=639200
@@ -48,12 +48,12 @@ stderr: 23th move(b): de, winrate=61.373413%, N=2270, Q=0.227468, p=0.697885, v=
 ```
 
 
-batch size 4
-tensorrt : OFF
-8 threads
-children : 64
-800M tree size 
-4000 sims
+- batch size 4
+- tensorrt : OFF
+- 8 threads
+- children : 64
+- 800M tree size 
+- 4000 sims
 
 ```
 stderr: 9th move(b): qj, winrate=48.316456%, N=1933, Q=-0.033671, p=0.323761, v=-0.057669, cost 30800.728516ms, sims=4007, height=44, avg_height=8.337065, global_step=639200
@@ -61,12 +61,12 @@ stderr: 11th move(b): fc, winrate=48.151749%, N=2050, Q=-0.036965, p=0.463283, v
 ```
 
 
-batch size 4
-tensorrt : ON
-8 threads
-children : 64
-800M tree size 
-4000 sims
+- batch size 4
+- tensorrt : ON
+- 8 threads
+- children : 64
+- 800M tree size 
+- 4000 sims
 
 ```
 stderr: 15th move(b): fq, winrate=50.587959%, N=832, Q=0.011759, p=0.111651, v=-0.014564, cost 25733.691406ms, sims=4008, height=24, avg_height=7.357091, global_step=639200
@@ -75,12 +75,12 @@ stderr: 19th move(b): fm, winrate=50.772697%, N=2403, Q=0.015454, p=0.320239, v=
 ```
 
 
-batch size 4
-tensorrt : OFF
-8 threads
-children : 64
-2000M tree size 
-4000 sims
+- batch size 4
+- tensorrt : OFF
+- 8 threads
+- children : 64
+- 2000M tree size 
+- 4000 sims
 
 ```
 stderr: 13th move(b): hc, winrate=55.519367%, N=1975, Q=0.110387, p=0.293458, v=0.101614, cost 33722.300781ms, sims=4008, height=23, avg_height=8.870925, global_step=639200
@@ -89,12 +89,12 @@ stderr: 17th move(b): ce, winrate=73.472389%, N=2986, Q=0.469448, p=0.264501, v=
 
 
 
-batch size 4
-tensorrt : ON
-8 threads
-children : 64
-2000M tree size 
-4000 sims
+- batch size 4
+- tensorrt : ON
+- 8 threads
+- children : 64
+- 2000M tree size 
+- 4000 sims
 
 ```
 stderr: 19th move(b): db, winrate=75.447426%, N=2739, Q=0.508949, p=0.501109, v=0.503591, cost 27647.033203ms, sims=4008, height=25, avg_height=5.634705, global_step=639200
@@ -102,12 +102,12 @@ stderr: 20th move(w): cb, winrate=-nan%, N=0, Q=-nan, p=0.000000, v=nan, cost 34
 ```
 
 
-batch size 4
-tensorrt : OFF
-8 threads
-children : 512
-400M tree size 
-4000 sims
+- batch size 4
+- tensorrt : OFF
+- 8 threads
+- children : 512
+- 400M tree size 
+- 4000 sims
 
 ```
 stderr: 23th move(b): cq, winrate=88.760635%, N=2396, Q=0.775213, p=0.193044, v=0.747791, cost 30913.226562ms, sims=4008, height=57, avg_height=14.380897, global_step=639200
@@ -115,12 +115,12 @@ stderr: 25th move(b): dq, winrate=86.716339%, N=3968, Q=0.734327, p=0.901415, v=
 ```
 
 
-batch size 4
-tensorrt : ON
-8 threads
-children : 512
-400M tree size 
-4000 sims
+- batch size 4
+- tensorrt : ON
+- 8 threads
+- children : 512
+- 400M tree size 
+- 4000 sims
 
 ```
 stderr: 9th move(b): cf, winrate=46.220604%, N=2333, Q=-0.075588, p=0.419347, v=-0.101920, cost 25676.927734ms, sims=4008, height=36, avg_height=6.813369, global_step=639200
@@ -128,12 +128,12 @@ stderr: 11th move(b): pj, winrate=47.592823%, N=1813, Q=-0.048144, p=0.472589, v
 ```
 
 
-batch size 4
-tensorrt : OFF
-8 threads
-children : 512
-2000M tree size 
-4000 sims
+- batch size 4
+- tensorrt : OFF
+- 8 threads
+- children : 512
+- 2000M tree size 
+- 4000 sims
 
 ```
 stderr: 1th move(b): dd, winrate=44.132729%, N=349, Q=-0.117345, p=0.080226, v=-0.120119, cost 31625.798828ms, sims=4008, height=10, avg_height=5.106929, global_step=639200
@@ -141,12 +141,12 @@ stderr: 3th move(b): qd, winrate=44.120907%, N=759, Q=-0.117582, p=0.163193, v=-
 ```
 
 
-batch size 4
-tensorrt : ON
-8 threads
-children : 512
-2000M tree size 
-4000 sims
+- batch size 4
+- tensorrt : ON
+- 8 threads
+- children : 512
+- 2000M tree size 
+- 4000 sims
 
 ```
 stderr: 5th move(b): qn, winrate=44.146938%, N=760, Q=-0.117061, p=0.164774, v=-0.116266, cost 26392.984375ms, sims=4008, height=31, avg_height=10.278131, global_step=639200
@@ -155,12 +155,12 @@ stderr: 7th move(b): nd, winrate=45.115017%, N=1026, Q=-0.097700, p=0.179594, v=
 
 ## BATCH SIZE 8 :
 
-batch size 8
-tensorrt : OFF
-16 threads
-children : 64
-400M tree size
-4000 sims
+- batch size 8
+- tensorrt : OFF
+- 16 threads
+- children : 64
+- 400M tree size
+- 4000 sims
 
 ```
 stderr: 29th move(b): dj, winrate=67.039803%, N=3292, Q=0.340796, p=0.809432, v=0.419116, cost 27238.894531ms, sims=4016, height=23, avg_height=3.907765, global_step=639200
@@ -170,12 +170,12 @@ stderr: 31th move(b): ek, winrate=69.330391%, N=4033, Q=0.386608, p=0.956573, v=
 
 ## BATCH SIZE 16 :
 
-batch size 16
-tensorrt : OFF
-24 threads
-children : 64
-400M tree size
-4000 sims
+- batch size 16
+- tensorrt : OFF
+- 24 threads
+- children : 64
+- 400M tree size
+- 4000 sims
 
 ```
 stderr: 35th move(b): mp, winrate=82.146217%, N=1159, Q=0.642924, p=0.216112, v=0.637870, cost 17744.708984ms, sims=4021, height=18, avg_height=6.282155, global_step=639200
@@ -185,12 +185,12 @@ stderr: 11th move(b): cp, winrate=50.521744%, N=3180, Q=0.010435, p=0.558747, v=
 ```
 
 
-batch size 16
-tensorrt : OFF
-32 threads
-children : 64
-400M tree size
-4000 sims
+- batch size 16
+- tensorrt : OFF
+- 32 threads
+- children : 64
+- 400M tree size
+- 4000 sims
 
 ```
 stderr: 9th move(b): cf, winrate=46.273342%, N=2667, Q=-0.074533, p=0.512861, v=-0.077746, cost 19605.994141ms, sims=4032, height=32, avg_height=4.803508, global_step=639200
@@ -200,12 +200,12 @@ stderr: 19th move(b): ef, winrate=81.741035%, N=828, Q=0.634821, p=0.166898, v=0
 ```
 
 
-batch size 16
-tensorrt : OFF
-32 threads
-children : 64
-2000M tree size
-4000 sims
+- batch size 16
+- tensorrt : OFF
+- 32 threads
+- children : 64
+- 2000M tree size
+- 4000 sims
 
 ```
 stderr: 21th move(b): be, winrate=71.451530%, N=3672, Q=0.429031, p=0.499344, v=0.430739, cost 17760.664062ms, sims=4032, height=20, avg_height=3.586761, global_step=639200
@@ -217,12 +217,12 @@ stderr: 5th move(b): qn, winrate=44.223949%, N=929, Q=-0.115521, p=0.156585, v=-
 ```
 
 
-batch size 16
-tensorrt : OFF
-32 threads
-children : 192
-2000M tree size
-4000 sims
+- batch size 16
+- tensorrt : OFF
+- 32 threads
+- children : 192
+- 2000M tree size
+- 4000 sims
 
 ```
 stderr: 17th move(b): je, winrate=52.257484%, N=2176, Q=0.045150, p=0.606293, v=0.074896, cost 17796.113281ms, sims=4032, height=21, avg_height=3.128364, global_step=639200
@@ -231,12 +231,12 @@ stderr: 25th move(b): fg, winrate=87.648285%, N=3418, Q=0.752966, p=0.333620, v=
 ```
 
 
-batch size 16
-tensorrt : OFF
-32 threads
-children : 512
-2000M tree size
-4000 sims
+- batch size 16
+- tensorrt : OFF
+- 32 threads
+- children : 512
+- 2000M tree size
+- 4000 sims
 
 ```
 stderr: 13th move(b): jc, winrate=50.131180%, N=3161, Q=0.002624, p=0.645318, v=0.021434, cost 17991.837891ms, sims=4032, height=21, avg_height=3.247312, global_step=639200
@@ -246,12 +246,12 @@ stderr: 23th move(b): df, winrate=87.167152%, N=3351, Q=0.743343, p=0.684157, v=
 
 ## BATCH SIZE 24 :
 
-batch size 24
-tensorrt : OFF
-32 threads
-children : 64
-400M tree size
-4000 sims
+- batch size 24
+- tensorrt : OFF
+- 32 threads
+- children : 64
+- 400M tree size
+- 4000 sims
 
 ```
 stderr: 21th move(b): mp, winrate=52.999252%, N=5199, Q=0.059985, p=0.369109, v=0.111925, cost 20766.712891ms, sims=4032, height=23, avg_height=9.521194, global_step=639200
@@ -260,12 +260,12 @@ stderr: 17th move(b): jc, winrate=63.067364%, N=3402, Q=0.261347, p=0.746740, v=
 ```
 
 
-batch size 24
-tensorrt : OFF
-48 threads
-children : 64
-400M tree size
-4000 sims
+- batch size 24
+- tensorrt : OFF
+- 48 threads
+- children : 64
+- 400M tree size
+- 4000 sims
 
 ```
 stderr: 25th move(b): kn, winrate=61.381878%, N=1679, Q=0.227638, p=0.331912, v=0.194674, cost 20769.664062ms, sims=4046, height=17, avg_height=2.412944, global_step=639200
@@ -275,12 +275,12 @@ stderr: 27th move(b): lo, winrate=64.118179%, N=1633, Q=0.282364, p=0.279228, v=
 
 ## BATCH SIZE 32 : 
 
-batch size 32
-tensorrt : OFF
-32 threads
-children : 64
-400M tree size
-4000 sims
+- batch size 32
+- tensorrt : OFF
+- 32 threads
+- children : 64
+- 400M tree size
+- 4000 sims
 
 ```
 stderr: 13th move(b): qq, winrate=57.209267%, N=2005, Q=0.144185, p=0.405177, v=0.122235, cost 17227.105469ms, sims=4030, height=34, avg_height=6.547671, global_step=639200
@@ -288,12 +288,12 @@ stderr: 17th move(b): rn, winrate=58.125191%, N=3115, Q=0.162504, p=0.632014, v=
 ```
 
 
-batch size 32
-tensorrt : OFF
-48 threads
-children : 64
-400M tree size
-4000 sims
+- batch size 32
+- tensorrt : OFF
+- 48 threads
+- children : 64
+- 400M tree size
+- 4000 sims
 
 ```
 stderr: 31th move(b): nn, winrate=86.338608%, N=2997, Q=0.726772, p=0.367060, v=0.754056, cost 17249.060547ms, sims=4048, height=17, avg_height=6.970535, global_step=639200
@@ -307,12 +307,12 @@ stderr: 9th move(b): jc, winrate=47.230457%, N=1498, Q=-0.055391, p=0.235233, v=
 ```
 
 
-batch size 32
-tensorrt : OFF
-64 threads
-children : 64
-400M tree size
-4000 sims
+- batch size 32
+- tensorrt : OFF
+- 64 threads
+- children : 64
+- 400M tree size
+- 4000 sims
 
 ```
 stderr: 21th move(b): od, winrate=75.232864%, N=1357, Q=0.504657, p=0.258191, v=0.459986, cost 15832.726562ms, sims=4064, height=22, avg_height=6.120484, global_step=639200
@@ -321,12 +321,12 @@ stderr: 23th move(b): oe, winrate=77.275383%, N=5187, Q=0.545508, p=0.983199, v=
 
 ## BATCH SIZE 48 : 
 
-batch size 48
-tensorrt : OFF
-64 threads
-children : 64
-400M tree size
-4000 sims
+- batch size 48
+- tensorrt : OFF
+- 64 threads
+- children : 64
+- 400M tree size
+- 4000 sims
 
 ```
 stderr: 29th move(b): qd, winrate=95.835518%, N=4095, Q=0.916710, p=0.985609, v=0.935179, cost 15217.651367ms, sims=4062, height=14, avg_height=6.751593, global_step=639200
@@ -334,12 +334,12 @@ stderr: 29th move(b): qd, winrate=95.835518%, N=4095, Q=0.916710, p=0.985609, v=
 
 ## BATCH SIZE 64 : 
 
-batch size 64
-tensorrt : OFF
-80 threads
-children : 64
-400M tree size
-4000 sims
+- batch size 64
+- tensorrt : OFF
+- 80 threads
+- children : 64
+- 400M tree size
+- 4000 sims
 
 ```
 stderr: 31th move(b): rc, winrate=96.647415%, N=241, Q=0.932948, p=0.078281, v=0.954536, cost 15016.847656ms, sims=4075, height=12, avg_height=2.383732, global_step=639200
@@ -354,21 +354,31 @@ for example speed gain +12% = 12% less time to calculate a move as compared
 to batch size 4 = 27.5 seconds vs 30.5 seconds per move = 4 seconds 
 difference out of 30.5 seconds 
 
-# CONCLUSIONS for GTX 1060 : 
+# CONCLUSIONS for GTX 1060 75W : 
 
-- TensorRT can increase speed by arround 15%-20% on a GTX 1060 with batch size 4 
-(for bigger batch size with tensorRT, see 
+- TensorRT can increase speed by arround 15%-20% on a GTX 1060 75W with 
+batch size 4 (for bigger batch size with tensorRT, see 
 [#75](https://github.com/Tencent/PhoenixGo/issues/75))
-- bigger batch size significantly increases speed of the engine on a GTX 1060 :
-     -> for batch size 8 , gain = +12%
-     -> for batch size 16 , gain = +33%
-     -> for batch size 24 , gain = +31%
-     -> for batch size 32 , gain = +47%
+- bigger batch size significantly increases speed of the engine on a 
+GTX 1060 75W :
+
+```
+-> for batch size 4 to 8 , gain = +12%
+-> for batch size 4 to 16 , gain = +33%
+-> for batch size 4 to 24 , gain = +31%
+-> for batch size 4 to 32 , gain = +47%
+```
+
+- batch sizes higher than 16 bring significant small increase speed 
+on gtx 1060 75W, but considering the loss of computing accuracy, 
+this is not an efficient choice
+- therefore, the most efficient batch size seems to be 16, providing 
+**an average 210 simulations per second on gtx1060 75W**
 - Compute device (GPU or CPU) utilization is higher with higher batching
-- gtx 1060 is too weak to benefit higher batch sizes than 32
+- gtx 1060 75W is too weak to benefit higher batch sizes than 32
 - number of threads does not significantly change speed of the engine
 - tree size does not significantly change the speed of the engine 
 (arround 5% more time with max tree size)
 
-# TO DO : 
-- i will try higher batch sizes with a Tesla V100 on windows 10
+For comparison, you can refer to 
+[tesla-V100-benchmark](benchmark-teslaV100.md)

--- a/docs/benchmark-teslaV100.md
+++ b/docs/benchmark-teslaV100.md
@@ -1,0 +1,192 @@
+# Benchmark setup :
+
+## setup
+- hardware : google cloud machine with Tesla V100-SXM2-16GB, 4 and 
+12vcpu (skylake server or later, support avx512, google cloud platform
+currently does not allow more than 12 vcpu per die, so maximum for 1 
+GPU is 12 vcpu = 6 physical cores / 12 cpu threads), 
+16gb system ram, 40 gb hdd
+- software : ubuntu 18.04 LTS, nvidia 410, cuda 10.0, cudnn 7.4.2, 
+no tensorrt, bazel 0.11.1
+- engine settings: limited time 60 seconds per move, all other time 
+management settings disabled in config file, all the rest is default 
+settings
+
+## methodology : 
+- most moves come from the same game played using 
+[gtp2ogs](https://github.com/online-go/gtp2ogs), for few moves moves, 
+copy paste stderr output
+- tensorRT is not used with the V100 here, because it would need to 
+build our own tensor model, which was not done here, see 
+[FAQ question](#a13-i-have-a-nvidia-rtx-card-turing-or-tesla-v100titan-v-volta-is-it-compatible-)
+for details
+
+## credits :
+- credit for doing this tests go to 
+[wonderingabout](https://github.com/wonderingabout)
+- credit for providing the hardware goes to google cloud 
+platform
+
+# BATCH SIZE 4 
+
+- batch size 4
+- tensorrt : OFF
+- 8 threads
+- children : 64
+- 400M tree size 
+- unlimited sims
+- 60s per move
+
+### 4 vcpu (2 physical cores/ 4 cpu threads) :
+
+`
+stderr: 4th move(w): pp, winrate=56.125683%, N=20226, Q=0.122514, p=0.728064, v=0.114009, cost 60014.109375ms, sims=22976, height=46, avg_height=12.719517, global_step=639200
+`
+
+### 12 vcpu (6 physical cores/ 12 cpu threads) :
+
+`
+stderr: 2th move(w): pd, winrate=56.061207%, N=6544, Q=0.121224, p=0.212260, v=0.106201, cost 60021.523438ms, sims=23096, height=30, avg_height=9.461098, global_step=639200
+`
+
+# BATCH SIZE 8
+
+- batch size 8
+- tensorrt : OFF
+- 16 threads
+- children : 96
+- 2000M tree size 
+- unlimited sims
+- 60s per move
+
+### 4 vcpu (2 physical cores/ 4 cpu threads) :
+
+`
+stderr: 8th move(w): nq, winrate=56.569016%, N=27010, Q=0.131380, p=0.591054, v=0.117058, cost 60036.335938ms, sims=32152, height=59, avg_height=14.057215, global_step=639200
+`
+
+### 12 vcpu (6 physical cores/ 12 cpu threads) :
+
+`
+stderr: 4th move(w): pp, winrate=56.120705%, N=28938, Q=0.122414, p=0.715722, v=0.114932, cost 60016.148438ms, sims=32728, height=54, avg_height=13.301727, global_step=639200
+`
+
+# BATCH SIZE 16 
+
+- batch size 16
+- tensorrt : OFF
+- 32 threads
+- children : 128
+- 2000M tree size 
+- unlimited sims
+- 60s per move
+
+### 4 vcpu (2 physical cores/ 4 cpu threads) :
+
+`
+stderr: 2th move(w): dp, winrate=56.057503%, N=15696, Q=0.121150, p=0.207913, v=0.105841, cost 60048.324219ms, sims=53568, height=34, avg_height=9.826570, global_step=639200
+`
+
+### 12 vcpu (6 physical cores/ 12 cpu threads) :
+
+`
+stderr: 6th move(w): qn, winrate=56.170525%, N=29628, Q=0.123410, p=0.306212, v=0.111480, cost 60020.058594ms, sims=53968, height=71, avg_height=14.943110, global_step=639200
+`
+
+# BATCH SIZE 32 
+
+- batch size 32
+- tensorrt : OFF
+- 64 threads
+- children : 128
+- 2000M tree size 
+- unlimited sims
+- 60s per move
+
+### 4 vcpu (2 physical cores/ 4 cpu threads) :
+
+`
+stderr: 10th move(w): cp, winrate=65.475777%, N=58821, Q=0.309516, p=0.886150, v=0.196629, cost 60111.078125ms, sims=59444, height=53, avg_height=10.118464, global_step=639200
+`
+
+### 12 vcpu (6 physical cores/ 12 cpu threads) :
+
+`
+stderr: 8th move(w): qf, winrate=56.714546%, N=55717, Q=0.134291, p=0.613282, v=0.114160, cost 60048.957031ms, sims=62368, height=64, avg_height=13.618808, global_step=639200
+`
+
+# BATCH SIZE 64 
+
+- batch size 64
+- tensorrt : OFF
+- 32 threads
+- children : 128
+- 2000M tree size 
+- unlimited sims
+- 60s per move
+
+### 4 vcpu (2 physical cores/ 4 cpu threads) :
+
+`
+stderr: 12th move(w): bo, winrate=65.815079%, N=64431, Q=0.316302, p=0.884180, v=0.226788, cost 60263.683594ms, sims=64960, height=54, avg_height=12.711725, global_step=639200
+`
+
+### 12 vcpu (6 physical cores/ 12 cpu threads) :
+
+`
+stderr: 10th move(w): pc, winrate=65.360603%, N=67943, Q=0.307212, p=0.887373, v=0.175454, cost 60165.914062ms, sims=69031, height=63, avg_height=7.840148, global_step=639200
+`
+
+# BATCH SIZE 128 
+
+- batch size 128
+- tensorrt : OFF
+- 256 threads
+- children : 128
+- 2000M tree size 
+- unlimited sims
+- 60s per move
+
+### 4 vcpu (2 physical cores/ 4 cpu threads) :
+
+`
+stderr: 16th move(w): rf, winrate=65.895859%, N=66225, Q=0.317917, p=0.937327, v=0.202470, cost 60232.250000ms, sims=67328, height=44, avg_height=10.560142, global_step=639200
+`
+
+### 12 vcpu (6 physical cores/ 12 cpu threads) :
+
+`
+stderr: 12th move(w): ob, winrate=65.983253%, N=70697, Q=0.319665, p=0.920173, v=0.223816, cost 60312.035156ms, sims=71664, height=49, avg_height=6.786881, global_step=639200
+`
+
+# CONCLUSIONS for Tesla V100 : 
+
+- all the conclusions below are without tensorRT optimization, which 
+is known to bring 15-30% extra computation performance depending on 
+hardware and settings :
+
+```
+-> for batch size 4 to 8 , gain = +43%
+-> for batch size 8 to 16 , gain = +60%
+-> for batch size 16 to 32 , gain = +14%
+-> for batch size 32 to 64 , gain = +10%
+-> for batch size 64 to 128 , gain = +3.7%
+```
+
+- batch sizes 8 and 16 significant great increases speed on Tesla 
+V100 with 6 cores / 12 cpu threads or less
+- batch sizes higher 16 to 64 bring significant small increase speed 
+on Tesla V100 with 6 cores / 12 cpu threads or less, but considering 
+the loss of computing accuracy, this is not an efficient choice
+- therefore, the most efficient batch size seems to be 16, providing 
+**an average 900 simulations per second on Tesla V100**, and a 135% 
+speed increase as compared to batch size 4
+- batch size higher than 64 do not bring significant speed increases on 
+Tesla V100 with 6 cores / 12 cpu threads or less
+
+- on the CPU side, as of February 2019, PhoenixGo engine does not 
+significantly benefit from a number of cpu threads higher than 2 
+cpu cores/ 4 cpu threads, even on Tesla V100
+
+For comparison, you can refer to 
+[gtx-1060-75w-benchmark](benchmark-gtx1060-75w.md)


### PR DESCRIPTION
@wodesuck 

general look here : https://github.com/wonderingabout/PhoenixGo/tree/faqv4-bazel-master

2 main changes in this PR : 

## 1) add benchmark Tesla V100 : 

this benchmark showed a few interesting conclusions : 

- batch size 16 is a very efficient batch size on Tesla V100,
providing an average 900 simulations per move, and a 130% 
speed boost as compared to batch size 4
- As of February 2019, PhoenixGo does not benefit from CPU
thread number higher than 2 cores / 4 threads on Tesla V100

These numbers may change if PhoenixGo supports newer Tensorflow
versions, as well as newer tensorRT versions too of course (latest is 
tensorRT 5.0 which brings native support for RTX and tesla V100)

latest stable version is tensorflow 1.13 
close to final release : https://github.com/tensorflow/tensorflow/releases

tensorflow 1.13 changelog says this in : https://github.com/tensorflow/tensorflow/releases/tag/v1.13.0-rc2

> TensorFlow GPU binaries are now built against **CUDA 10 and TensorRT 5.0.**

so i think it would be very great to support tensorflow 1.13 with PhoenixGo

benchmark gtx1060 75W has been slightly updated as well

## 2) add "undo" on readme + add FAQ question + other minor readme changes

other minor readme updates (i checked on `list_commands` 
and `undo` appears at the bottom of the list now)
another new FAQ question A8.

conclusion : after merging this, i think it PhoenixGo may want to look at 
tensorflow support of newer versions like 1.12 or 1.3, as well as 
tensorRT 5.0 (to add support for RTX cards, and native support for Volta 
(no need to build model anymore))